### PR TITLE
Add function to compute plate circulation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,8 +8,10 @@ makedocs(
         "Getting Started Guide" => "quickstart.md",
         "Vortex Elements" => "elements.md",
         "Computing Velocities" => "velocities.md",
-        "Time Marching" => "timemarching.md"
+        "Time Marching" => "timemarching.md",
+        "Enforcing No-Flow-Through" => "noflowthrough.md"
     ],
+    assets = ["assets/custom.css"],
     strict = true
 )
 

--- a/docs/src/assets/custom.css
+++ b/docs/src/assets/custom.css
@@ -1,0 +1,3 @@
+details[open] {
+    background-color: #efefef;
+}

--- a/docs/src/noflowthrough.md
+++ b/docs/src/noflowthrough.md
@@ -206,7 +206,7 @@ So the final expression for the bound circulation is:
 ```math
 \begin{equation}
 \gamma[l(s)] =
-\frac{-\frac{2\Gamma_A}{L\pi} - 2(A_0 - \unormal \cdot \vec{\dot{c}}) T_1(s) + (A_1 - \frac{\dot{\alpha}L}{2})T_2(s)}{\sqrt{1 - s^2}} - 2\sqrt{1 - s^2}\sum_{n = 2}^\infty A_n U_{n-1}(s)
+\frac{-\frac{2\Gamma_A}{L\pi} + 2(A_0 - \unormal \cdot \vec{\dot{c}}) T_1(s) + (A_1 - \frac{\dot{\alpha}L}{2})T_2(s)}{\sqrt{1 - s^2}} - 2\sqrt{1 - s^2}\sum_{n = 2}^\infty A_n U_{n-1}(s)
 \label{eq:gamma}
 \end{equation}
 ```
@@ -214,7 +214,7 @@ So the final expression for the bound circulation is:
     This might look more similar to results from thin-airfoil theory if we rewrite the Chebyshev polynomials using trigonometric functions:
     ```math
     \gamma[l(\theta)] =
-    \frac{-\frac{2\Gamma_A}{L\pi} - 2(A_0 - \unormal \cdot \vec{\dot{c}}) \cos\theta + (A_1 - \frac{\dot{\alpha}L}{2})\cos(2\theta)}{\sin\theta} - 2\sum_{n = 2}^\infty A_n \sin(n\theta).
+    \frac{-\frac{2\Gamma_A}{L\pi} + 2(A_0 - \unormal \cdot \vec{\dot{c}}) \cos\theta + (A_1 - \frac{\dot{\alpha}L}{2})\cos(2\theta)}{\sin\theta} - 2\sum_{n = 2}^\infty A_n \sin(n\theta).
     ```
     The key difference is that we are free to relax the Kutta condition at the trailing edge.
 
@@ -247,7 +247,7 @@ $$
 & = \int_{\cos^{-1} s}^\pi \cos(n\theta) \d{\theta} \\
 & = \begin{cases}
 \pi - \cos^{-1}s &: n = 0 \\
-\frac{1}{n}\sin\left(n\cos^{-1}s\right) &: n > 0
+-\frac{1}{n}\sin\left(n\cos^{-1}s\right) &: n > 0
 \end{cases}.
 \end{align*}
 $$
@@ -256,7 +256,7 @@ We can then multiply the expressions above with their corresponding coefficients
 ```
 ```math
 \Gamma[l(s)]
-=\Gamma_A\left(\cos^{-1}s - \pi\right) - \frac{L\sqrt{1 - s^2}}{2}\left[
+=\Gamma_A\left(\frac{\cos^{-1}s}{\pi} - 1\right) - \frac{L\sqrt{1 - s^2}}{2}\left[
 2\left(A_0 - \unormal \cdot \vec{\dot{c}}\right)
 +\left(A_1 - \frac{\dot{\alpha}L}{2}\right)s
 +\sum_{n=2}^\infty

--- a/docs/src/noflowthrough.md
+++ b/docs/src/noflowthrough.md
@@ -1,0 +1,266 @@
+# Enforcing No-Flow-Through
+
+!!! warning
+    Under construction...
+
+```math
+\def\ddt#1{\frac{\mathrm{d}#1}{\mathrm{d}t}}
+
+\renewcommand{\vec}{\boldsymbol}
+\newcommand{\uvec}[1]{\vec{\hat{#1}}}
+\newcommand{\utangent}{\uvec{\tau}}
+\newcommand{\unormal}{\uvec{n}}
+
+\renewcommand{\d}{\,\mathrm{d}}
+
+\newcommand{\cross}{\times}
+\newcommand{\abs}[1]{\left|#1\right|}
+\newcommand{\im}{\mathrm{i}}
+\newcommand{\eu}{\mathrm{e}}
+\newcommand{\pint}{\int}
+\newcommand{\conj}[1]{#1^\star}
+\newcommand{\Res}[2]{\mathrm{Res}\left(#1,#2\right)}
+\newcommand{\real}[1]{\mathrm{Re}\left\{#1\right\}}
+\newcommand{\imag}[1]{\mathrm{Im}\left\{#1\right\}}
+```
+We are interested in enforcing the no-flow-through condition on an infinitely thin, flat plate undergoing rigid body motion.
+The plate can be parameterized by its length, ``L``, centroid position, ``\vec{c}``, and its angle of attack, ``\alpha``.
+Its motion is then specified by its centroid velocity, ``\dot{\vec{c}}``, and angular velocity, ``\dot{\vec{\alpha}}``.
+
+## Vortex Sheet Strength
+
+The plate is represented with a bound vortex sheet that constantly adjusts its circulation to enforce no-flow-through on its surface.
+We can show that the distribution of circulation, ``\gamma``, is governed by the following integral equation:
+```@raw html
+<details>
+<summary></summary>
+The no-flow-through condition requires that the component of fluid velocity normal to the sheet must be equal to the normal velocity of the sheet itself, i.e.
+$$
+\begin{align*}
+    \unormal \cdot \vec{u}(\vec{x}_s)
+& = \unormal \cdot \left[ \dot{\vec{c}} + \dot{\alpha} \cross (\vec{x}_s - \vec{c}) \right] \\
+& = \left(\unormal \cdot \vec{c}\right) + \dot{\alpha} l
+\end{align*}
+$$
+where
+
+- $\vec{u}$ is the fluid velocity
+- $\vec{x}_s$ is a position on the plate
+- $\unormal$ is a unit vector normal to the plate
+- $l \in [ -L/2, L/2 ] $ is distance between $\vec{x}_s$ from the plate centroid
+
+We can decompose the velocity field at any point in the fluid into contributions from the bound vortex sheet, $\vec{u}_s$, and the free vorticity in the ambient fluid, $\vec{u}_A$:
+$$
+\vec{u}(\vec{x}) = \vec{u}_s(\vec{x}) + \vec{u}_A(\vec{x}),
+$$
+so the no-flow-through condition can be written as:
+$$
+\unormal \cdot \vec{u}_s(\vec{x}) = \left(\unormal \cdot \vec{c}\right) + \dot{\alpha} l - \unormal \cdot \vec{u}_A(\vec{x}).
+$$
+
+The velocity field induced by a vortex sheet, $\vec{u}_x(\vec{x})$, is given by
+$$
+\vec{u}_s(\vec{x}) = \frac{1}{2\pi}
+\int_\mathcal{C} \gamma(l) \,\uvec{k} \cross
+\frac{\vec{x} - \vec{x}_s(l)}{\abs{\vec{x} - \vec{x}_s(l)}^2}
+\d{l}
+$$
+where
+
+- $\gamma$ is the strength of the sheet
+- $\mathcal{C}$ is the curve occupied by the sheet
+- $\uvec{k}$ is the unit vector point out of the plane.
+
+The position along the vortex sheet can be expressed as
+$$
+\vec{x}_s(l) = \vec{c} + l\utangent
+$$
+where $\utangent$ is the unit tangent along the sheet.
+Similarly, since we are interested in evaluating the velocity along the sheet, we can write
+$$
+\vec{x}(l) = \vec{c} + \lambda\utangent.
+$$
+We can then write self-induced velocity of the bound vortex sheet as
+$$
+\vec{u}_s(\lambda) = \frac{\unormal}{2\pi}
+\int_{-\frac{L}{2}}^\frac{L}{2} \frac{\gamma(l)}{\lambda - l}
+\d{l}.
+$$
+Substituting this expression back into the no-flow-through condition, we get
+</p>
+</details>
+```
+```math
+\begin{equation}
+\frac{1}{2\pi}
+\int_{-L/2}^{L/2} \frac{\gamma(\lambda)}{l - \lambda}
+\d{\lambda}
+= \unormal \cdot \vec{\dot{c}}
++ \dot{\alpha} l
+- \unormal \cdot \vec{u}_A(l)
+\label{eq:integral-equation}
+\end{equation}
+```
+The solution to this integral equation can be found in [^Muskhelishvili].
+If the velocity induced by ambient vorticity on the plate can be expanded into a Chebyshev series:
+```math
+\unormal \cdot \vec{u}_A[l(s)] = \sum_{n = 0} A_n T_n(s),
+```
+and ``\Gamma_A`` is the total circulation in the ambient fluid, then the solution to ``\eqref{eq:integral-equation}`` can be written as:
+```@raw html
+<details>
+<summary> </summary>
+To make it easier to work with Chebyshev series, we will apply a change of variables $s := \frac{2l}{L}$ so that the integral above goes from $-1$ to $1$:
+$$
+\frac{1}{2\pi}
+\int_{-1}^1 \frac{\gamma(s)}{\sigma - s}
+\d{s}
+= \unormal \cdot \vec{\dot{c}}
++ \frac{\dot{\alpha}L}{2} \sigma
+- \unormal \cdot \vec{u}_A(\sigma)
+$$
+From <a href="#footnote-Muskhelishvili">[Muskhelishvili]</a>, we have that if
+$$
+\frac{1}{\pi\im} \int \frac{\varphi(t)}{t - t_0} \d{t} = f(t_0)
+$$
+then
+$$
+\varphi(t_0) = \frac{1}{\pi\im\sqrt{t_0 - 1}\sqrt{t_0 + 1}}
+\int \frac{\sqrt{t - 1}\sqrt{t + 1}}{t - t_0} f(t) \d{t}
++
+\frac{P(t_0)}{\sqrt{t_0 - 1}\sqrt{t_0 + 1}}
+$$
+where $P$ is an arbitrary polynomial that must be chosen to satisfy far-field boundary conditions.
+
+In our case, we have $\varphi := \im \gamma$ and
+$$
+f := 2\sum_{n = 0}^\infty A_n T_n(\sigma) - 2\unormal \cdot \vec{\dot{c}} - \dot{\alpha}L \sigma
+$$
+so
+$$
+\gamma(\sigma)
+=
+\frac{-2}{\pi\sqrt{1 - \sigma}\sqrt{1 + \sigma}}
+\int_{-1}^1 \frac{\sqrt{1 - s}\sqrt{1 + s}}{s - \sigma}
+\left(
+\sum_{n = 0}^\infty A_n T_n(s) - \unormal \cdot \vec{\dot{c}} - \frac{\dot{\alpha}L}{2} s
+\right) \d{s}
++
+\frac{P(t_0)}{\sqrt{1 - \sigma}\sqrt{1 + \sigma}}
+$$
+
+The integral above is made of terms with the form
+$$
+\pint_{-1}^1
+\frac{\sqrt{1 - s}\sqrt{1 + s}}{s - \sigma} T_n(s)
+\d{s}
+$$
+which we can simplify using the properties of Chebyshev polynomials into
+$$
+\pint_{-1}^1
+\frac{\sqrt{1 - s}\sqrt{1 + s}}{s - \sigma} T_n(s)
+\d{s}
+=
+\begin{cases}
+-\pi T_1(\sigma) & n = 0 \\
+-\frac{\pi}{2} T_2(\sigma) & n = 1 \\
+-\frac{\pi}{2} \left[T_{n+1}(\sigma) - T_{n-1}(\sigma)\right] & n \ge 2
+\end{cases}.
+$$
+This gives us
+$$
+\gamma(\sigma)
+=
+\frac{-2}{\pi\sqrt{1 - \sigma}\sqrt{1 + \sigma}}
+\left\{
+-\pi A_0 \sigma
+-\frac{\pi}{2} A_1
++\sum_{n = 1}^\infty -\frac{\pi}{2}A_n \left[T_{n+1}(\sigma) - T_{n-1}(\sigma)\right]
++ \pi \left(\unormal \cdot \vec{\dot{c}}\right)\sigma
++ \frac{\pi}{2}T_2(\sigma)\frac{\dot{\alpha}L}{2}
+\right\}
++
+\frac{P(t_0)}{\sqrt{1 - \sigma}\sqrt{1 + \sigma}}.
+$$
+
+We can find $P$ by satisfying Kelvin's circulation theorem.
+This means that the amount of circulation contained in the bound vortex sheet should the negative of the circulation contained in the ambient vorticity, i.e.
+$$
+\Gamma_s := \int_{-\frac{L}{2}}^{\frac{L}{2}} \gamma \d{l} = -\Gamma_A
+$$
+
+Again, we use properties of Chebyshev polynomials to reduce the integral to
+$$
+\begin{align*}
+\frac{L}{2}\int_{-1}^1 \frac{P(s)}{\sqrt{1 - s}\sqrt{1 + s}} \d{s} & = -\Gamma_A,
+\end{align*}
+$$
+which means that
+$$
+P = -\frac{2\Gamma_A}{L\pi}.
+$$
+
+So the final expression for the bound circulation is:
+</details>
+```
+```math
+\begin{equation}
+\gamma[l(s)] =
+\frac{-\frac{2\Gamma_A}{L\pi} - 2(A_0 - \unormal \cdot \vec{\dot{c}}) T_1(s) + (A_1 - \frac{\dot{\alpha}L}{2})T_2(s)}{\sqrt{1 - s^2}} - 2\sqrt{1 - s^2}\sum_{n = 2}^\infty A_n U_{n-1}(s)
+\label{eq:gamma}
+\end{equation}
+```
+!!! note
+    This might look more similar to results from thin-airfoil theory if we rewrite the Chebyshev polynomials using trigonometric functions:
+    ```math
+    \gamma[l(\theta)] =
+    \frac{-\frac{2\Gamma_A}{L\pi} - 2(A_0 - \unormal \cdot \vec{\dot{c}}) \cos\theta + (A_1 - \frac{\dot{\alpha}L}{2})\cos(2\theta)}{\sin\theta} - 2\sum_{n = 2}^\infty A_n \sin(n\theta).
+    ```
+    The key difference is that we are free to relax the Kutta condition at the trailing edge.
+
+## Circulation
+
+In addition to the distribution of circulation along the plate, it will be useful to know the amount circulation contained between one end of the plate to an arbitrary point on its surface.
+By definition, we have
+```math
+\begin{align*}
+\Gamma(l) & = \int_{-L/2}^l \gamma(\lambda) \d{\lambda} \\
+\Gamma[l(s)] &= \frac{L}{2}\int_{-1}^s \gamma[l(\sigma)] \d{\sigma}.
+\end{align*}
+```
+We can integrate ``\gamma`` term by term to obtain:
+```@raw html
+<details>
+<summary></summary>
+In equation $\eqref{eq:gamma}$, the Chebyshev polynomial of the second kind in ther summation can be written in terms of Chebyshev polynomials of the first kind:
+$$
+2\sqrt{1 - s^2}U_{n-1}(s)  = \frac{T_{n-1}(s) - T_{n+1}(s)}{\sqrt{1 - s^2}}.
+$$
+This means that all the terms in equation $\eqref{eq:gamma}$ can be expressed in the form:
+$$
+\frac{T_n(s)}{\sqrt{1 - s^2}}.
+$$
+The integral of these terms are:
+$$
+\begin{align*}
+\int_{-1}^s \frac{T_n(s)}{\sqrt{1 - s^2}} \d{s}
+& = \int_{\cos^{-1} s}^\pi \cos(n\theta) \d{\theta} \\
+& = \begin{cases}
+\pi - \cos^{-1}s &: n = 0 \\
+\frac{1}{n}\sin\left(n\cos^{-1}s\right) &: n > 0
+\end{cases}.
+\end{align*}
+$$
+We can then multiply the expressions above with their corresponding coefficients to obtain:
+</details>
+```
+```math
+\Gamma[l(s)]
+=\Gamma_A\left(\cos^{-1}s - \pi\right) - \frac{L\sqrt{1 - s^2}}{2}\left[
+2\left(A_0 - \unormal \cdot \vec{\dot{c}}\right)
++\left(A_1 - \frac{\dot{\alpha}L}{2}\right)s
++\sum_{n=2}^\infty
+A_n \left(\frac{U_n(s)}{n+1} - \frac{U_{n-2}(s)}{n-1}\right)\right]
+```
+
+[^Muskhelishvili]: Muskhelishvili, Nikolaĭ Ivanovich, and Jens Rainer Maria Radok. Singular integral equations: boundary problems of function theory and their application to mathematical physics. Courier Corporation, 2008.

--- a/src/elements/plates/circulation.jl
+++ b/src/elements/plates/circulation.jl
@@ -13,17 +13,17 @@ function strength(plate, s::Real)
 
     γ = 0.0
 
-    U₋ = 0.0
-    U  = 1.0
-    for n in 1:N-1
+    U₋ = 1.0
+    U  = 2s
+    for n in 2:N-1
         γ += 2A[n]*U
         U₋, U = U, 2s*U - U₋
     end
     γ *= (s^2 - 1)
 
-    γ += A[1] + 2Γ/(L*π)
-    γ +=    2(A[0] - B₀)*s
-    γ +=             -B₁*(2s^2 - 1)
+    γ += 2Γ/(L*π)
+    γ += 2(A[0] - B₀)*s
+    γ +=  (A[1] - B₁)*(2s^2 - 1)
 
     if abs2(γ) < 256eps()
         γ = 0.0
@@ -45,13 +45,66 @@ end
 Compute the bound vortex sheet strength of `plate` and store it in `γs`.
 
 If an array, `ss`, with normalized arc length coordinates is omitted,
-then the circulation will be computed at the plate's Chebyshev nodes.
+then the strength will be computed at the plate's Chebyshev nodes.
 """
-strength!(γs, plate) = strength!(γs, plate, plate.ss)
-
-function strength!(γs, plate, ss)
+function strength!(γs, plate, ss = plate.ss)
     for (i, s) in enumerate(ss)
         γs[i] = strength(plate, s)
+    end
+    nothing
+end
+
+"""
+    bound_circulation(plate[, s])
+
+Compute the bound circulation between the trailing edge of the plate to `s`.
+
+`s` can be either a single normalized arc length coordinate (between
+-1 and 1), or a whole array of coordinates.
+"""
+bound_circulation(plate) = bound_circulation(plate, plate.ss)
+
+function bound_circulation(plate, s::Real)
+    @get plate (A, B₀, B₁, L, Γ, N)
+
+    Γₛ = 0.0
+
+
+    Γₛ  = 2(A[0] - B₀)
+    Γₛ +=  (A[1] - B₁)*s
+
+    U₋₂ = 1.0
+    U₋  = 2s
+    U   = 4s^2 - 1
+
+    for n in 2:N-1
+        Γₛ += A[n]*(U/(n+1) - U₋₂/(n-1))
+        U₋₂, U₋, U = U₋, U, 2s*U - U₋
+    end
+    Γₛ *= -0.5L*√(1 - s^2)
+
+    Γₛ -= Γ*(acos(s)/π - 1)
+
+    return Γₛ
+end
+
+function bound_circulation(plate, ss::AbstractArray{T}) where {T <: Real}
+    Γs = zeros(Float64, length(ss))
+    bound_circulation!(Γs, plate, ss)
+    return Γs
+end
+
+"""
+    bound_circulation!(Γs, plate[, ss])
+
+Compute the bound circulation between the trailing edge of the plate to `ss`, then store it in `Γs`.
+
+If an array, `ss`, with normalized arc length coordinates is omitted,
+then the circulation will be computed at the plate's Chebyshev nodes.
+"""
+function bound_circulation!(Γs, plate, ss = plate.ss)
+    for (i, s) in enumerate(ss)
+        Γs[i] = bound_circulation(plate, s)
     end
     nothing
 end

--- a/src/elements/plates/circulation.jl
+++ b/src/elements/plates/circulation.jl
@@ -1,18 +1,18 @@
 """
-    bound_circulation(plate[, s])
+    strength(plate[, s])
 
-Compute the bound circulation on the plate.
+Compute the bound vortex sheet strength of the plate.
 
 `s` can be either a single normalized arc length coordinate (between
 -1 and 1), or a whole array of coordinates.
 """
-bound_circulation(plate) = bound_circulation(plate, plate.ss)
+strength(plate) = strength(plate, plate.ss)
 
-function bound_circulation(plate, s::Real)
+function strength(plate, s::Real)
     @get plate (A, α, B₀, B₁, L, Γ, N)
 
     γ = 0.0
-    
+
     U₋ = 0.0
     U  = 1.0
     for n in 1:N-1
@@ -33,26 +33,25 @@ function bound_circulation(plate, s::Real)
     return γ
 end
 
-function bound_circulation(plate, ss::AbstractArray{T}) where {T <: Real}
+function strength(plate, ss::AbstractArray{T}) where {T <: Real}
     γs = zeros(Float64, length(ss))
-    bound_circulation!(γs, plate, ss)
+    strength!(γs, plate, ss)
     return γs
 end
 
 """
-    bound_circulation!(γs, plate[, ss])
+    strength!(γs, plate[, ss])
 
-Compute the bound circulation of `plate` and store it in `γs`.
+Compute the bound vortex sheet strength of `plate` and store it in `γs`.
 
 If an array, `ss`, with normalized arc length coordinates is omitted,
 then the circulation will be computed at the plate's Chebyshev nodes.
 """
-bound_circulation!(γs, plate) = bound_circulation!(γs, plate, plate.ss)
+strength!(γs, plate) = strength!(γs, plate, plate.ss)
 
-function bound_circulation!(γs, plate, ss)
+function strength!(γs, plate, ss)
     for (i, s) in enumerate(ss)
-        γs[i] = bound_circulation(plate, s)
+        γs[i] = strength(plate, s)
     end
     nothing
 end
-

--- a/test/Plates.jl
+++ b/test/Plates.jl
@@ -135,13 +135,12 @@
         kutta_points = Vortex.Point.(rand(Complex128, 2), 1.0)
         Vortex.Plates.vorticity_flux!(plate, kutta_points[1], kutta_points[2])
 
-        ss = linspace(-1, 1, 2001)
+        ss = linspace(-1, 1, 4001)
         γs = Vortex.Plates.strength(plate, ss)
         Γs = Vortex.Plates.bound_circulation(plate, ss)
         @test Γs[ceil(Int,length(ss)/2)] ≈ Vortex.Plates.bound_circulation(plate)[ceil(Int,length(plate)/2)]
 
-        @test norm(γs - gradient(Γs, step(ss)))/length(ss) < 1e-4
-
+        @test norm(γs - gradient(Γs, step(ss)))/length(ss) < 1e-3
     end
 
     @testset "Induced Velocities" begin

--- a/test/Plates.jl
+++ b/test/Plates.jl
@@ -105,7 +105,7 @@
         zs = c .+ 0.5.*exp(im*α).*(ζs .+ 1./ζs)
         Γs = 1 .- 2.*rand(N)
 
-        Np = 128
+        Np = 129
         J = JoukowskyMap(c, α)
 
         Δż_circle = map(linspace(π, 0, Np)) do θ
@@ -131,6 +131,16 @@
         @test maximum(abs2.(γs[2:end-1] .- real.(Δż_circle[2:end-1]))) ≤ 256eps()
 
         @test γs == Vortex.Plates.strength(plate)
+
+        kutta_points = Vortex.Point.(rand(Complex128, 2), 1.0)
+        Vortex.Plates.vorticity_flux!(plate, kutta_points[1], kutta_points[2])
+
+        ss = linspace(-1, 1, 2001)
+        γs = Vortex.Plates.strength(plate, ss)
+        Γs = Vortex.Plates.bound_circulation(plate, ss)
+        @test Γs[ceil(Int,length(ss)/2)] ≈ Vortex.Plates.bound_circulation(plate)[ceil(Int,length(plate)/2)]
+
+        @test norm(γs - gradient(Γs, step(ss)))/length(ss) < 1e-4
 
     end
 

--- a/test/Plates.jl
+++ b/test/Plates.jl
@@ -127,10 +127,10 @@
         plate_vel = Vortex.Plates.PlateMotion(ċ, α̇)
         Vortex.Plates.enforce_no_flow_through!(plate, plate_vel, points)
         γs = zeros(Float64, Np)
-        Vortex.Plates.bound_circulation!(γs, plate)
+        Vortex.Plates.strength!(γs, plate)
         @test maximum(abs2.(γs[2:end-1] .- real.(Δż_circle[2:end-1]))) ≤ 256eps()
 
-        @test γs == Vortex.Plates.bound_circulation(plate)
+        @test γs == Vortex.Plates.strength(plate)
 
     end
 
@@ -191,7 +191,7 @@
 
         _, b₋ = Vortex.Plates.suction_parameters(plate)
         @test abs(b₋) ≤ eps()
-        @test Vortex.Plates.bound_circulation(plate, -1) == 0
+        @test Vortex.Plates.strength(plate, -1) == 0
         @test C ≈ plate.C
 
         Vortex.Plates.enforce_no_flow_through!(plate, plate_vel, ())
@@ -202,7 +202,7 @@
         Vortex.Plates.enforce_no_flow_through!(plate, plate_vel, Vortex.Point(-Inf, Γ))
         b₊, _ = Vortex.Plates.suction_parameters(plate)
         @test abs(b₊) ≤ eps()
-        @test Vortex.Plates.bound_circulation(plate, 1) == 0
+        @test Vortex.Plates.strength(plate, 1) == 0
 
         Vortex.Plates.enforce_no_flow_through!(plate, plate_vel, ())
         Γ₊, Γ₋, _, _ = Vortex.Plates.vorticity_flux(plate, point, point, Inf, Inf)


### PR DESCRIPTION
The `bound_circulation` function used to compute the bound vortex sheet strength, which is actually the derivative of circulation with respect to the sheet arc length.  Those functions were renamed to `strength`,
and `bound_circulation[!]` now computes the amount of circulation between the trailing edge of the sheet (s = -1) and any point along the sheet.

This also adds some derivations of the bound vortex sheet to the documentation.