### PR TITLE
Generalize `at-property` macro

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ Documenter
 DocStringExtensions
 Interpolations
 Reexport
+MacroTools

--- a/src/Vortex.jl
+++ b/src/Vortex.jl
@@ -358,7 +358,7 @@ self_induce_velocity(src) = _self_induce_velocity(src, kind(unwrap_src(src)))
 _self_induce_velocity(src, ::Type{Singleton}) = zero(Complex128)
 function _self_induce_velocity(src, ::Type{Group})
     out = allocate_velocity(src)
-    self_induce_velocity(out, src)
+    self_induce_velocity!(out, src)
 end
 
 """

--- a/src/Vortex.jl
+++ b/src/Vortex.jl
@@ -397,6 +397,9 @@ function advect!(group₊::T, group₋::T, ws, Δt) where {T <: Tuple}
     nothing
 end
 
+#== Acceleration ==#
+@property induced acceleration Complex128 (targvel,) (srcvel,)
+
 @submodule "elements/Points"
 @submodule "elements/Blobs"
 @submodule "elements/Sheets"

--- a/src/Vortex.jl
+++ b/src/Vortex.jl
@@ -39,12 +39,30 @@ export allocate_velocity, reset_velocity!,
 #== Type Definitions ==#
 
 abstract type Element end
-abstract type PointSource <: Element end
-abstract type CompositeSource <: Element end
-
 const Collection = Union{AbstractArray, Tuple}
-const PointArray = AbstractArray{T} where {T <: PointSource}
-const TargetTypes = (Complex128, PointSource, CompositeSource, Collection)
+
+#== Trait definitions ==#
+abstract type Singleton end
+abstract type Group end
+
+function kind end
+
+macro kind(element, k)
+    esc(quote
+        Vortex.kind(::$element) = $k
+        Vortex.kind(::Type{$element}) = $k
+    end)
+end
+
+@kind Complex128 Singleton
+kind(::AbstractArray{T}) where {T <: Union{Element, Complex128}} = Group
+kind(::Tuple) = Group
+
+# Convenience functions to define wrapper types
+# e.g. vortex sheets as a wrapper around vortex blobs
+unwrap_src(e) = unwrap(e)
+unwrap_targ(e) = unwrap(e)
+unwrap(e) = e
 
 #== Vortex Properties ==#
 
@@ -169,6 +187,7 @@ function reset_velocity!(group::T, src) where {T <: Tuple}
 end
 
 @property induced velocity Complex128
+#@property_traits induced velocity Complex128
 
 @doc """
     allocate_velocity(srcs)
@@ -308,35 +327,38 @@ julia> vels # should be ±0.25im/π
  0.0+0.0795775im
 ```
 """
-function self_induce_velocity!(ws, group::Tuple)
+function self_induce_velocity!(out, group::Tuple)
     N = length(group)
     for s in 1:N
-        self_induce_velocity!(ws[s], group[s])
+        self_induce_velocity!(out[s], group[s])
         for t in s+1:N
-            mutually_induce_velocity!(ws[s], ws[t], group[s], group[t])
+            mutually_induce_velocity!(out[s], out[t], group[s], group[t])
         end
     end
-    nothing
+    out
 end
 
-"""
-    self_induce_velocity(src)
+function self_induce_velocity!(out, src)
+    _self_induce_velocity!(out, unwrap_src(src), kind(unwrap_src(src)))
+end
 
-Compute the self induced velocity of a point source.
-If this method is not implemented for a subtype of `Vortex.PointSource`, the fallback function returns `0.0+0.0im`
-"""
-self_induce_velocity(::PointSource) = zero(Complex128)
-
-function self_induce_velocity!(ws, array::PointArray)
-    N = length(array)
+function _self_induce_velocity!(out, src, ::Type{Group})
+    N = length(src)
     for s in 1:N
-        ws[s] += self_induce_velocity(array[s])
+        out[s] += self_induce_velocity(src[s])
         for t in s+1:N
-            ws[s] += induce_velocity(array[s], array[t])
-            ws[t] += induce_velocity(array[t], array[s])
+            out[s] += induce_velocity(src[s], src[t])
+            out[t] += induce_velocity(src[t], src[s])
         end
     end
-    nothing
+    out
+end
+
+self_induce_velocity(src) = _self_induce_velocity(src, kind(unwrap_src(src)))
+_self_induce_velocity(src, ::Type{Singleton}) = zero(Complex128)
+function _self_induce_velocity(src, ::Type{Group})
+    out = allocate_velocity(src)
+    self_induce_velocity(out, src)
 end
 
 """

--- a/src/elements/Blobs.jl
+++ b/src/elements/Blobs.jl
@@ -14,7 +14,7 @@ An immutable structure representing a vortex blob
 - `Γ`: circulation
 - `δ`: blob radius
 """
-struct Blob <: Vortex.PointSource
+struct Blob <: Vortex.Element
     z::Complex128
     Γ::Float64
     δ::Float64
@@ -29,6 +29,8 @@ blob_kernel(z, δ) = 0.5im*z/(π*(abs2(z) + δ^2))
 function Vortex.induce_velocity(z::Complex128, b::Blob)
     b.Γ*blob_kernel(z - b.z, b.δ)
 end
+
+@Vortex.kind Blob Vortex.Singleton
 
 function Vortex.induce_velocity(target::Blob, source::Blob)
     δ = √(0.5(target.δ^2 + source.δ^2))

--- a/src/elements/Plates.jl
+++ b/src/elements/Plates.jl
@@ -9,7 +9,6 @@ import ..Vortex:@get, MappedVector
 import Base: length
 
 include("plates/chebyshev.jl")
-#import Chebyshev
 
 """
     Vortex.Plate <: VortexCompositeSource
@@ -22,7 +21,7 @@ $(FIELDS)
 # Constructors
 - `Plate(N, L, c, α)`
 """
-mutable struct Plate <: Vortex.CompositeSource
+mutable struct Plate <: Vortex.Element
     "chord length"
     L::Float64
     "centroid"
@@ -102,14 +101,15 @@ function Vortex.induce_velocity(z::Complex128, p::Plate)
     0.5im*w*exp(im*α)
 end
 
-function Vortex.induce_velocity!(ws::Vector, p::Plate, sources::Vortex.Collection)
+function Vortex.induce_velocity!(ws::Vector, p::Plate, sources::T) where T <: Union{Tuple, AbstractArray}
     for source in sources
         Vortex.induce_velocity!(ws, p, source)
     end
     ws
 end
 
-Vortex.induce_velocity!(ws::Vector, p::Plate, ps::Vortex.PointSource) = Vortex.induce_velocity!(ws, p.zs, ps)
+@Vortex.kind Plate Vortex.Singleton
+Vortex.unwrap_targ(p::Plate) = p.zs
 
 function Vortex.induce_velocity!(ws::Vector, p::Plate, b::Vortex.Blob)
     for (i, z) in enumerate(p.zs)
@@ -169,7 +169,7 @@ function unit_impulse(z::Complex128, plate::Plate)
     unit_impulse(z̃)
 end
 unit_impulse(z̃) = -im*(z̃ + real(√(z̃ - 1)*√(z̃ + 1) - z̃))
-unit_impulse(src::Vortex.PointSource, plate::Plate) = unit_impulse(Vortex.position(src), plate)
+unit_impulse(src, plate::Plate) = unit_impulse(Vortex.position(src), plate)
 
 include("plates/boundary_conditions.jl")
 include("plates/circulation.jl")

--- a/src/elements/Plates.jl
+++ b/src/elements/Plates.jl
@@ -111,22 +111,20 @@ end
 @Vortex.kind Plate Vortex.Singleton
 Vortex.unwrap_targ(p::Plate) = p.zs
 
-function Vortex.induce_velocity!(ws::Vector, p::Plate, b::Vortex.Blob)
-    for (i, z) in enumerate(p.zs)
-        ws[i] += b.Γ*Vortex.Points.cauchy_kernel(z - b.z)
-    end
-    ws
+function Vortex.induce_velocity!(ws::Vector, p::Plate, src)
+    _singular_velocity!(ws, p, Vortex.unwrap(src),
+                        Vortex.kind(Vortex.unwrap_src(src)))
 end
 
-function Vortex.induce_velocity!(ws::Vector, p::Plate, blobs::Vector{Vortex.Blob})
-    for (i, z) in enumerate(p.zs), b in blobs
-        ws[i] += b.Γ*Vortex.Points.cauchy_kernel(z - b.z)
-    end
-    ws
+function _singular_velocity!(ws, p, src, ::Type{Vortex.Singleton})
+    Vortex.induce_velocity!(ws, p.zs, Vortex.Point(src))
 end
 
-function Vortex.induce_velocity!(ws::Vector, p::Plate, s::Vortex.Sheet)
-    Vortex.induce_velocity!(ws, p, s.blobs)
+function _singular_velocity!(ws, p, src, ::Type{Vortex.Group})
+    for i in eachindex(src)
+        Vortex.induce_velocity!(ws, p, src[i])
+    end
+    ws
 end
 
 mutable struct PlateMotion

--- a/src/elements/Points.jl
+++ b/src/elements/Points.jl
@@ -13,7 +13,7 @@ An immutable structure representing a point vortex
 - `z`: position
 - `Γ`: circulation
 """
-struct Point <: Vortex.PointSource
+struct Point <: Vortex.Element
     z::Complex128
     Γ::Float64
 end
@@ -27,6 +27,8 @@ cauchy_kernel(z) = z != zero(z) ? 0.5im/(π*conj(z)) : zero(z)
 function Vortex.induce_velocity(z::Complex128, p::Point)
     p.Γ*cauchy_kernel(z - p.z)
 end
+
+@Vortex.kind Point Vortex.Singleton
 
 function Vortex.mutually_induce_velocity!(ws₁, ws₂,
                                           points₁::Vector{Point},

--- a/src/elements/Points.jl
+++ b/src/elements/Points.jl
@@ -18,6 +18,8 @@ struct Point <: Vortex.Element
     Γ::Float64
 end
 
+Point(e::Vortex.Element) = Point(Vortex.position(e), Vortex.circulation(e))
+
 Vortex.position(p::Point) = p.z
 Vortex.circulation(p::Point) = p.Γ
 Vortex.impulse(p::Point) = -im*p.z*p.Γ

--- a/src/elements/Sheets.jl
+++ b/src/elements/Sheets.jl
@@ -23,12 +23,14 @@ A vortex sheet represented by vortex blob control points
 - `Sheet(blobs, Γs, δ)`
 - `Sheet(zs, Γs, δ)` where `zs` is an array of positions for the control points
 """
-mutable struct Sheet <: Vortex.CompositeSource
+mutable struct Sheet <: Vortex.Element
     blobs::Vector{Vortex.Blob}
     Γs::Vector{Float64}
     δ::Float64
     zs::MappedPositions
 end
+
+Vortex.unwrap(s::Sheet) = s.blobs
 
 function Sheet(zs::AbstractVector{T}, Γs::AbstractVector{Float64}, δ::Float64) where {T <: Number}
     dΓs = compute_trapezoidal_weights(Γs)
@@ -49,16 +51,16 @@ length(s::Sheet) = length(s.blobs)
 Vortex.circulation(s::Sheet) = s.Γs[end] - s.Γs[1]
 Vortex.impulse(s::Sheet) = Vortex.impulse(s.blobs)
 
-Vortex.allocate_velocity(s::Sheet) = zeros(Complex128, length(s.blobs))
-
-
-for T in Vortex.TargetTypes
-    @eval Vortex.induce_velocity(t::$T, s::Sheet) = Vortex.induce_velocity(t, s.blobs)
-end
-Vortex.induce_velocity(t::Sheet, source) = Vortex.induce_velocity(t.blobs, source)
-Vortex.induce_velocity(t::Sheet, s::Sheet) = Vortex.induce_velocity(t.blobs, s.blobs)
-
-Vortex.induce_velocity!(ws::Vector, s::Sheet, source) = Vortex.induce_velocity!(ws, s.blobs, source)
+#Vortex.allocate_velocity(s::Sheet) = zeros(Complex128, length(s.blobs))
+#
+#
+#for T in Vortex.TargetTypes
+#    @eval Vortex.induce_velocity(t::$T, s::Sheet) = Vortex.induce_velocity(t, s.blobs)
+#end
+#Vortex.induce_velocity(t::Sheet, source) = Vortex.induce_velocity(t.blobs, source)
+#Vortex.induce_velocity(t::Sheet, s::Sheet) = Vortex.induce_velocity(t.blobs, s.blobs)
+#
+#Vortex.induce_velocity!(ws::Vector, s::Sheet, source) = Vortex.induce_velocity!(ws, s.blobs, source)
 
 function Vortex.mutually_induce_velocity!(ws₁, ws₂, sheet₁::Sheet, sheet₂::Sheet)
     Vortex.mutually_induce_velocity!(ws₁, ws₂, sheet₁.blobs, sheet₂.blobs)

--- a/src/property.jl
+++ b/src/property.jl
@@ -1,7 +1,7 @@
 using MacroTools
 
 """
-    @property kind name property_type
+    @property kind name property_type [target_deps source_deps]
 
 Macro to define common functions for computing vortex properties
 
@@ -11,7 +11,7 @@ Macro to define common functions for computing vortex properties
   ```julia
   allocate_<name>(target)
   induce_<name>(target, source)
-  induce_<name>!(output, target, source)
+  induce_<name>!(output, target[, target_deps], source[, source_deps])
   ```
   where `source` can be
   - a single vortex element (e.g. a single point vortex)
@@ -20,6 +20,10 @@ Macro to define common functions for computing vortex properties
   `target` can be the same types as `source` as well as one or more positions,
   and `output` is the output array allocated by `allocate_<name>`
   The return type of `induce_<name>` will be `property_type`.
+  `target_deps` and `source_deps` are optional dependencies that might
+  be required to compute the induced property.  For example, for
+  computing induced acceleration, we need the velocity of both the
+  target and source.
 - `point`: when the property is pointwise defined (e.g. position),
   the macro defines a placeholder function
   ```julia

--- a/test/dispatch.jl
+++ b/test/dispatch.jl
@@ -49,6 +49,7 @@
     # Self-induce velocities
     Vortex.reset_velocity!(ws)
     Vortex.self_induce_velocity!(ws, sys)
+    @test ws == Vortex.self_induce_velocity(sys)
 
     wb = Vortex.allocate_velocity(blobs)
     Vortex.induce_velocity!(wb, blobs, blobs)

--- a/test/dispatch.jl
+++ b/test/dispatch.jl
@@ -79,7 +79,7 @@
 
     @testset "defaults" begin
         # Minimum implementation of a vortex point source
-        @eval struct NewPoint <: Vortex.PointSource
+        @eval struct NewPoint <: Vortex.Element
             z::Complex128
             Γ::Float64
         end
@@ -87,6 +87,9 @@
         Vortex.position(p::NewPoint) = p.z
         Vortex.circulation(p::NewPoint) = p.Γ
         Vortex.impulse(p::NewPoint) = -im*p.z*p.Γ
+
+        Vortex.kind(::NewPoint) = Vortex.Singleton
+        Vortex.kind(::Type{NewPoint}) = Vortex.Singleton
 
         function Vortex.induce_velocity(z::Complex128, p::NewPoint)
             p.Γ*Vortex.Points.cauchy_kernel(z - p.z)


### PR DESCRIPTION
- [x] Switch to a traits-based implementation
- [x] Add optional variables when generating induced properties
- [ ] ~~Add acceleration as an example (should make it easier to compute surface pressures)~~ *Not actually easier to compute pressure especially when dealing with vortex shedding*
- [x] Update documentation