### PR TITLE
Use `PlotRecipes` to directly plot vortex elements

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,7 @@
 julia 0.6-
 Documenter
 DocStringExtensions
+RecipesBase
 Interpolations
 Reexport
 MacroTools

--- a/src/Vortex.jl
+++ b/src/Vortex.jl
@@ -29,8 +29,6 @@ using .Utils
 
 include("property.jl")
 
-include("plotting.jl")
-
 using DocStringExtensions
 
 export allocate_velocity, reset_velocity!,
@@ -448,5 +446,7 @@ end
 @submodule "elements/Blobs"
 @submodule "elements/Sheets"
 @submodule "elements/Plates"
+
+include("plotting.jl")
 
 end

--- a/src/Vortex.jl
+++ b/src/Vortex.jl
@@ -29,6 +29,8 @@ using .Utils
 
 include("property.jl")
 
+include("plotting.jl")
+
 using DocStringExtensions
 
 export allocate_velocity, reset_velocity!,
@@ -39,6 +41,7 @@ export allocate_velocity, reset_velocity!,
 #== Type Definitions ==#
 
 abstract type Element end
+
 
 #== Trait definitions ==#
 abstract type Singleton end
@@ -433,6 +436,12 @@ function advect!(group₊::T, group₋::T, ws, Δt) where {T <: Tuple}
         advect!(group₊[i], group₋[i], ws[i], Δt)
     end
     nothing
+end
+
+@property begin
+    signature = induce_acc(targ::Target, targvel::Target, src::Source, srcvel::Source)
+    preallocator = allocate_acc
+    stype = Complex128
 end
 
 @submodule "elements/Points"

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,0 +1,37 @@
+using RecipesBase
+
+@recipe function plot(points::Array{P}) where P <: Union{Vortex.Blob, Vortex.Point}
+    z = Vortex.position(points)
+    Γ = Vortex.circulation.(points)
+    marker_z --> Γ
+    seriestype --> :scatter
+    x := real.(z)
+    y := imag.(z)
+    ()
+end
+
+@recipe function plot(s::Sheet)
+    z = s.zs
+    Γ = Vortex.circulation.(s.blobs)
+    line_z --> Γ
+    x := real.(z)
+    y := imag.(z)
+    ()
+end
+
+@recipe function plot(p::Vortex.Plate)
+    z = [p.zs[1], p.zs[end]]
+    linecolor --> :black
+    x := real.(z)
+    y := imag.(z)
+    ()
+end
+
+const VortexSystem = NTuple{N, Union{Element, Tuple, Array{V} where {V <: Element}}} where N
+function RecipesBase.RecipesBase.apply_recipe(plotattributes::Dict{Symbol, Any}, sys::Vortex.VortexSystem)
+    series_list = RecipesBase.RecipeData[]
+    for s in sys
+        append!(series_list, RecipesBase.RecipesBase.apply_recipe(copy(plotattributes), s) )
+    end
+    series_list
+end


### PR DESCRIPTION
- [x] define recipes for built-in vortex elements
- [ ] convert documentation/examples
- [ ] add docs