### PR TITLE
Added a new flag called clamp_constraints to vorticity_flux

### DIFF
--- a/test/Utils.jl
+++ b/test/Utils.jl
@@ -19,6 +19,8 @@ import PotentialFlow.Utils: @get, MappedVector
 
         buff = IOBuffer()
         show(buff, y)
-        @test String(take!(buff)) == "Array{Float64,1} → typeof(cos) (0:2)"
+        @test String(take!(buff)) == "Vector{Float64} → typeof(cos) (0:2)"
+        #@test String(take!(buff)) == "Array{Float64,1} → typeof(cos) (0:2)"
+
     end
 end


### PR DESCRIPTION
This returns the lesp and tesp constraints to the old way by default (`clamp_constraints=false`), in which vorticity wouldn't be added if the edge condition was satisfied.  Setting `clamp_constraints=true` sets new vorticity at such edges, though it seems on reflection that the conditions are incorrectly constrained in these cases.