### PR TITLE
Completed more of the use of preserve_circ flag

### DIFF
--- a/src/autodiff/apiutils.jl
+++ b/src/autodiff/apiutils.jl
@@ -4,7 +4,7 @@
 end
 
 function seed!(duals::AbstractArray{<:ComplexDual{T,V,M}}, x,
-               rseed::Partials{M,V} = zero(Partials{M,V}),iseed::Partials{M,V} = zero(Partials{M,V})) where {T,V,N,M}
+               rseed::Partials{M,V} = zero(Partials{M,V}),iseed::Partials{M,V} = zero(Partials{M,V})) where {T,V,M}
     for i in eachindex(duals)
         duals[i] = ComplexDual{T,V,M}(x[i],rseed,iseed)
     end

--- a/src/autodiff/dual.jl
+++ b/src/autodiff/dual.jl
@@ -79,7 +79,7 @@ end
 @inline Base.@propagate_inbounds dz_partials(::Type{T}, d::AbstractVector{ComplexDual{T,V,N}}, i...) where {T,V,N} = dz_partials(d, i...)
 
 # Given complex Partials for d/dz and d/dz*, return partials for dr/dx,y and di/dx,y
-@inline function reim_partials(dz::Partials{N,V},dzstar::Partials{N,V}) where {T,V<:Complex,N}
+@inline function reim_partials(dz::Partials{N,V},dzstar::Partials{N,V}) where {V<:Complex,N}
     drx, dix = reim(dz+dzstar)
     dry, diy = reim(im*dz-im*dzstar)
     return _splice_xy(drx,dry), _splice_xy(dix,diy)

--- a/src/elements/bodies/basisfields.jl
+++ b/src/elements/bodies/basisfields.jl
@@ -40,7 +40,7 @@ about its reference point
 @inline Fbr(ζ,b::ConformalBody) = Elements.complexpotential(ζ,_set_motion_in_quiescent(b,0.0,0.0,1.0))
 
 """
-    Fv(ζ,b::ConformalBody,v::Element)
+    Fv(ζ,b::ConformalBody,v::Element[;preserve_circ=false])
 
 Calculate ``\\hat{F}_{v}``, the complex potential at `ζ` in the circle plane due to a unit-strength vortex at the location of `v`,
 along with its images inside the body `b`. It is presumed that the location of `v` is given in the circle plane.
@@ -385,13 +385,13 @@ function _dphivdζv(ζ,b::Bodies.ConformalBody,v::Element)
 end
 
 """
-    wvv(targ::Element,src::Element,b::ConformalBody)
+    wvv(targ::Element,src::Element,b::ConformalBody;[preserve_circ=false])
 
 Calculate the complex velocity ``w = u - iv`` of the target element `targ` due to element `src` with unit strength,
 also accounting for the images of `src`. If `targ` and `src` are the same element, then
 it makes the Routh correction.
 """
-@inline wvv(targ::Element,src::Element,b::Bodies.ConformalBody) = wv(targ.z,b,src) +
+@inline wvv(targ::Element,src::Element,b::Bodies.ConformalBody;preserve_circ=DEFAULT_PRESERVE_CIRC_FLAG) = wv(targ.z,b,src;preserve_circ=preserve_circ) +
                                                                    conj(Bodies.transform_velocity(conj(_routh(targ.z,b,Val(targ==src))),targ.z,b))
 
 """
@@ -466,14 +466,14 @@ function dwvvdz_src(targ::Element,src::Element,b::Bodies.ConformalBody)
 end
 
 """
-    dwvvdz_targ(targ::Element,src::Element,b::ConformalBody)
+    dwvvdz_targ(targ::Element,src::Element,b::ConformalBody;[preserve_circ=false])
 
 Calculate the derivative of the complex velocity ``w = u - iv`` of
 induced on the target element `targ` by the element `src` with unit strength,
 with respect to physical-plane position of `targ`.
 """
-function dwvvdz_targ(targ::Element,src::Element,b::Bodies.ConformalBody)
-  out = dwvvdzeta_targ(targ,src,b)
+function dwvvdz_targ(targ::Element,src::Element,b::Bodies.ConformalBody;preserve_circ=DEFAULT_PRESERVE_CIRC_FLAG)
+  out = dwvvdzeta_targ(targ,src,b;preserve_circ=preserve_circ)
   return conj(Bodies.transform_velocity(conj(out),targ.z,b))
 end
 

--- a/src/elements/bodies/pressure.jl
+++ b/src/elements/bodies/pressure.jl
@@ -461,25 +461,25 @@ function P(ζ,v::Element,b::Bodies.ConformalBody)
 end
 =#
 
-function Πvv(ζ,targ::Element,src::Element,b::Bodies.ConformalBody)
-    return real(wv(ζ,b,targ).*conj(wv(ζ,b,src))) +
-           2.0*real(dphivdzv(ζ,b,targ)*conj(wvv(targ,src,b))) +
-           2.0*real(dphivdzv(ζ,b,src)*conj(wvv(src,targ,b)))
+function Πvv(ζ,targ::Element,src::Element,b::Bodies.ConformalBody;kwargs...)
+    return real(wv(ζ,b,targ;kwargs...).*conj(wv(ζ,b,src;kwargs...))) +
+           2.0*real(dphivdzv(ζ,b,targ;kwargs...)*conj(wvv(targ,src,b;kwargs...))) +
+           2.0*real(dphivdzv(ζ,b,src)*conj(wvv(src,targ,b;kwargs...)))
 end
 
-dΠvvdzv(ζ,targ::Element,src::Element,b::Bodies.ConformalBody) = _dΠvvdzv_targ(ζ,targ,src,b)
+dΠvvdzv(ζ,targ::Element,src::Element,b::Bodies.ConformalBody;kwargs...) = _dΠvvdzv_targ(ζ,targ,src,b;kwargs...)
 
 # This computes the derivative of Πvv with respect to the
 # target's position. Note that the derivative with respect to
 # the source's position is simply the same with targ and src swapped.
-function _dΠvvdzv_targ(ζ,targ::Element,src::Element,b::Bodies.ConformalBody)
-    out = dwvdzv(ζ,b,targ).*conj(wv(ζ,b,src)) +
-          2.0*d2phivdzv2(ζ,b,targ)*conj(wvv(targ,src,b)) +
+function _dΠvvdzv_targ(ζ,targ::Element,src::Element,b::Bodies.ConformalBody;kwargs...)
+    out = dwvdzv(ζ,b,targ).*conj(wv(ζ,b,src;kwargs...)) +
+          2.0*d2phivdzv2(ζ,b,targ)*conj(wvv(targ,src,b;kwargs...)) +
           2.0*dphivdzv(ζ,b,targ)*conj(dwvvdzstar_targ(targ,src,b)) +
           2.0*dphivdzv(ζ,b,src)*conj(dwvvdzstar_src(src,targ,b))
-    out += conj(dwvdzvstar(ζ,b,targ).*conj(wv(ζ,b,src)) +
-          2.0*d2phivdzvdzvstar(ζ,b,targ)*conj(wvv(targ,src,b)) +
-          2.0*dphivdzv(ζ,b,targ)*conj(dwvvdz_targ(targ,src,b)) +
+    out += conj(dwvdzvstar(ζ,b,targ).*conj(wv(ζ,b,src;kwargs...)) +
+          2.0*d2phivdzvdzvstar(ζ,b,targ)*conj(wvv(targ,src,b;kwargs...)) +
+          2.0*dphivdzv(ζ,b,targ)*conj(dwvvdz_targ(targ,src,b;kwargs...)) +
           2.0*dphivdzv(ζ,b,src)*conj(dwvvdz_src(src,targ,b)))
     return 0.5*out
 end
@@ -511,8 +511,8 @@ for (wtype,c,comp) in [(:inf1,:U,:x),(:inf2,:V,:y),(:rinf,:Ω,:r)]
 
   # ΠUv, ΠVv, ΠΩv
   # switched from 4 to 2 in front of second term
-  @eval function $Πfcn(ζ,v::Element,b::Bodies.ConformalBody)
-      return -real(conj($winf(ζ,b)).*wv(ζ,b,v)) -
+  @eval function $Πfcn(ζ,v::Element,b::Bodies.ConformalBody;kwargs...)
+      return -real(conj($winf(ζ,b)).*wv(ζ,b,v;kwargs...)) -
              2.0*real(dphivdzv(ζ,b,v)*conj($winf(v.z,b)))
   end
 
@@ -530,22 +530,22 @@ for (wtype,c,comp) in [(:inf1,:U,:x),(:inf2,:V,:y),(:rinf,:Ω,:r)]
   end
 
   # Fvv_x, Fvv_y, Fvv_r
-  @eval function $Ffcn(targ::Element,src::Element,b::ConformalBody)
+  @eval function $Ffcn(targ::Element,src::Element,b::ConformalBody;kwargs...)
     winf_targ = $winf(targ.z,b)
     winf_src = $winf(src.z,b)
-    return imag(winf_targ*conj(wvv(targ,src,b))) + imag(winf_src*conj(wvv(src,targ,b)))
+    return imag(winf_targ*conj(wvv(targ,src,b;kwargs...))) + imag(winf_src*conj(wvv(src,targ,b;kwargs...)))
   end
 
   # dFvv_xdzv, dFvv_ydzv, dFvv_rdzv (with respect to target)
-  @eval function $dFfcn(targ::Element,src::Element,b::ConformalBody)
+  @eval function $dFfcn(targ::Element,src::Element,b::ConformalBody;kwargs...)
     winf_targ = $winf(targ.z,b)
     dwinf_targ = $dwinfdz(targ.z,b)
     dwinfstar_targ = $dwinfdzstar(targ.z,b)
-    wvv_targ = wvv(targ,src,b)
+    wvv_targ = wvv(targ,src,b;kwargs...)
     winf_src = $winf(src.z,b)
 
     out = dwinf_targ*conj(wvv_targ)+ winf_targ*conj(dwvvdzstar_targ(targ,src,b))
-    out -= conj(dwinfstar_targ)*wvv_targ + conj(winf_targ)*dwvvdz_targ(targ,src,b)
+    out -= conj(dwinfstar_targ)*wvv_targ + conj(winf_targ)*dwvvdz_targ(targ,src,b;kwargs...)
     out += winf_src*conj(dwvvdzstar_src(src,targ,b))
     out -= conj(winf_src)*dwvvdz_src(src,targ,b)
     return -0.5im*out
@@ -553,7 +553,8 @@ for (wtype,c,comp) in [(:inf1,:U,:x),(:inf2,:V,:y),(:rinf,:Ω,:r)]
 end
 
 
-
+# Note that these rely on unit_impulse of the vortex, which only
+# strictly computes the impulse for the image of equal/opposite strength.
 
 function FUv_x(v::Element,b::ConformalBody)
   Pv = unit_impulse(v,b)

--- a/src/elements/source/diff.jl
+++ b/src/elements/source/diff.jl
@@ -34,12 +34,12 @@ for fiip in (:seed!,)
       vseed .= Blob.(posduals,real(strduals),Elements.blobradius(v))
   end
 
-  @eval function $fiip(vseed::Vector{<:Point},v::Vector{<:Point},posduals,strduals,index) where {N,V,M}
+  @eval function $fiip(vseed::Vector{<:Point},v::Vector{<:Point},posduals,strduals,index)
       $fiip(posduals,strduals,flux,v,index)
       vseed .= Point.(posduals,real(strduals))
   end
 
-  @eval function $fiip(vseed::Vector{<:Blob},v::Vector{<:Blob},posduals,strduals,index) where {N,V,M}
+  @eval function $fiip(vseed::Vector{<:Blob},v::Vector{<:Blob},posduals,strduals,index)
       $fiip(posduals,strduals,flux,v,index)
       vseed .= Blob.(posduals,real(strduals),Elements.blobradius(v))
   end

--- a/src/elements/vortex/diff.jl
+++ b/src/elements/vortex/diff.jl
@@ -34,12 +34,12 @@ for fiip in (:seed!,)
       vseed .= Blob.(posduals,real(strduals),Elements.blobradius(v))
   end
 
-  @eval function $fiip(vseed::Vector{<:Point},v::Vector{<:Point},posduals,strduals,index) where {N,V,M}
+  @eval function $fiip(vseed::Vector{<:Point},v::Vector{<:Point},posduals,strduals,index)
       $fiip(posduals,strduals,circulation,v,index)
       vseed .= Point.(posduals,real(strduals))
   end
 
-  @eval function $fiip(vseed::Vector{<:Blob},v::Vector{<:Blob},posduals,strduals,index) where {N,V,M}
+  @eval function $fiip(vseed::Vector{<:Blob},v::Vector{<:Blob},posduals,strduals,index)
       $fiip(posduals,strduals,circulation,v,index)
       vseed .= Blob.(posduals,real(strduals),Elements.blobradius(v))
   end


### PR DESCRIPTION
This PR fixes some missing entries of `preserve_circ` in the `ConformalBody` routines. This flag is used to set whether a vortex is placed at the center of the unit circle (if set to `true`) or nor (if set to `false`, the default).